### PR TITLE
Feat/users list

### DIFF
--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import Layout from '../../components/wrappers/Layout';
 import AdminSidebar from '../../components/wrappers/AdminSidebar';
 import { Badge } from '../../components/ui/badge';
@@ -17,71 +18,47 @@ import {
   TableRow,
 } from '../../components/ui/table';
 
-import { Switch } from '../../components/ui/switch';
+import { useGetUsersQuery, useUpdateUserMutation } from '../api/usersApi';
+import { toast } from '../../components/ui/use-toast';
+import { Button } from '../../components/ui/button';
 
 export default function Users() {
-  const users = [
-    {
-      Name: 'Juan Pérez',
-      Email: 'juan.perez@example.com',
-      Status: 'Activo',
-      Balance: 150075,
-    },
-    {
-      Name: 'María López',
-      Email: 'maria.lopez@example.com',
-      Status: 'Inactivo',
-      Balance: 275050,
-    },
-    {
-      Name: 'Carlos García',
-      Email: 'carlos.garcia@example.com',
-      Status: 'Activo',
-      Balance: 12500,
-    },
-    {
-      Name: 'Ana Martínez',
-      Email: 'ana.martinez@example.com',
-      Status: 'Activo',
-      Balance: 320020,
-    },
-    {
-      Name: 'Luis Rodríguez',
-      Email: 'luis.rodriguez@example.com',
-      Status: 'Activo',
-      Balance: 5000,
-    },
-    {
-      Name: 'Carmen Sánchez',
-      Email: 'carmen.sanchez@example.com',
-      Status: 'Activo',
-      Balance: 74580,
-    },
-    {
-      Name: 'Miguel Fernández',
-      Email: 'miguel.fernandez@example.com',
-      Status: 'Activo',
-      Balance: 43000,
-    },
-    {
-      Name: 'Elena Gómez',
-      Email: 'elena.gomez@example.com',
-      Status: 'Inactivo',
-      Balance: 120050,
-    },
-    {
-      Name: 'Sofía Díaz',
-      Email: 'sofia.diaz@example.com',
-      Status: 'Activo',
-      Balance: 98025,
-    },
-    {
-      Name: 'Pedro Torres',
-      Email: 'pedro.torres@example.com',
-      Status: 'Activo',
-      Balance: 210000,
-    },
-  ];
+  const { data, isLoading } = useGetUsersQuery('');
+  const [updateUser] = useUpdateUserMutation();
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    if (data) {
+      setUsers(data.data);
+    }
+  }, [data]);
+
+  const handleStaffChange = async (user_id, is_staff) => {
+    const body = { id: user_id, is_staff: !is_staff };
+    try {
+      await updateUser(body).unwrap();
+      setUsers((prevUsers) =>
+        prevUsers.map((user) =>
+          user.id === user_id ? { ...user, is_staff: !is_staff } : user
+        )
+      );
+      toast({
+        title: !is_staff
+          ? 'El usuario ahora es staff'
+          : 'El usuario ya no es staff',
+        description: 'Cambio realizado exitosamente',
+      });
+    } catch (error) {
+      toast({
+        title: 'Error',
+        description: `Error al realizar el cambio: ${error.message}`,
+      });
+    }
+  };
+
+  if (isLoading) {
+    return <div className='flex justify-center'>Loading...</div>;
+  }
   return (
     <Layout>
       <div className='grid min-h-screen w-full md:grid-cols-[220px_1fr] lg:grid-cols-[280px_1fr]'>
@@ -107,7 +84,7 @@ export default function Users() {
                           Saldo disponible
                         </TableHead>
                         <TableHead className='text-right'>
-                          Activar/Desactivar Cuenta
+                          Acticar/Desactivar Staff
                         </TableHead>
                       </TableRow>
                     </TableHeader>
@@ -115,18 +92,29 @@ export default function Users() {
                       {users.map((user) => (
                         <TableRow className='bg-accent'>
                           <TableCell>
-                            <div className='font-medium'>{user.Name}</div>
+                            <div className='font-medium'>{user.name}</div>
                           </TableCell>
                           <TableCell className='hidden sm:table-cell'>
-                            {user.Email}
+                            {user.email}
                           </TableCell>
                           <TableCell className='hidden sm:table-cell'>
                             <Badge className='text-xs' variant='secondary'>
-                              ${user.Balance}
+                              ${user.balance}
                             </Badge>
                           </TableCell>
                           <TableCell className='text-right'>
-                            <Switch />
+                            <Button
+                              className={
+                                user.is_staff
+                                  ? 'bg-black text-slate-100'
+                                  : 'bg-slate-100 text-black'
+                              }
+                              onClick={() => {
+                                handleStaffChange(user.id, user.is_staff);
+                              }}
+                            >
+                              {user.is_staff ? 'Desactivar' : 'Activar'}
+                            </Button>
                           </TableCell>
                         </TableRow>
                       ))}

--- a/pages/api/usersApi.ts
+++ b/pages/api/usersApi.ts
@@ -13,7 +13,7 @@ export const userApi = createApi({
         headers: {
           'Content-Type': 'application/json',
           Authorization:
-            // TODO: Change this to a real token
+            //  TODO: Change this to a real token
             'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzIwMDU3MzQ1LCJqdGkiOiI0NzQyOGI5NTNhMTU0MzRiODU4YjE3YjcxNDYwMWUyZiIsInVzZXJfaWQiOiI2MDRkMDNkNy0xYmVjLTQ5NjUtODA2OS03ZjRkZTMxYjM1NjIifQ.qVn0_Xp_rzXh5MusCWOgDkx_Rfx0sn3gg-chVeemEMo',
         },
       }),

--- a/pages/api/usersApi.ts
+++ b/pages/api/usersApi.ts
@@ -1,0 +1,38 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export const userApi = createApi({
+  reducerPath: 'userApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: 'http://localhost:8000/api/v1/user',
+  }),
+  endpoints: (builder) => ({
+    getUsers: builder.query({
+      query: () => ({
+        url: '/all/',
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization:
+            // TODO: Change this to a real token
+            'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzIwMDU0OTk0LCJqdGkiOiJlNmVhNjc4NWJlZjg0NTMxODI0NThjZmQ3MjczYTZiYyIsInVzZXJfaWQiOiIwNmIyYmY5My0xZmVlLTQ1ODctODdmOC1kMjk4Y2U1Yjc1MzEifQ.ZoF-g6D8Vcv3Ioc1udK4JjeR6_krWOy1uq2BSQnlxSs',
+        },
+      }),
+    }),
+
+    updateUser: builder.mutation({
+      query: (user) => ({
+        url: `/staff/?id=${user.id}`,
+        method: 'PUT',
+        body: user,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization:
+            // TODO: Change this to a real token
+            'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzIwMDU0OTk0LCJqdGkiOiJlNmVhNjc4NWJlZjg0NTMxODI0NThjZmQ3MjczYTZiYyIsInVzZXJfaWQiOiIwNmIyYmY5My0xZmVlLTQ1ODctODdmOC1kMjk4Y2U1Yjc1MzEifQ.ZoF-g6D8Vcv3Ioc1udK4JjeR6_krWOy1uq2BSQnlxSs',
+        },
+      }),
+    }),
+  }),
+});
+
+export const { useGetUsersQuery, useUpdateUserMutation } = userApi;

--- a/pages/api/usersApi.ts
+++ b/pages/api/usersApi.ts
@@ -14,7 +14,7 @@ export const userApi = createApi({
           'Content-Type': 'application/json',
           Authorization:
             // TODO: Change this to a real token
-            'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzIwMDU0OTk0LCJqdGkiOiJlNmVhNjc4NWJlZjg0NTMxODI0NThjZmQ3MjczYTZiYyIsInVzZXJfaWQiOiIwNmIyYmY5My0xZmVlLTQ1ODctODdmOC1kMjk4Y2U1Yjc1MzEifQ.ZoF-g6D8Vcv3Ioc1udK4JjeR6_krWOy1uq2BSQnlxSs',
+            'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzIwMDU3MzQ1LCJqdGkiOiI0NzQyOGI5NTNhMTU0MzRiODU4YjE3YjcxNDYwMWUyZiIsInVzZXJfaWQiOiI2MDRkMDNkNy0xYmVjLTQ5NjUtODA2OS03ZjRkZTMxYjM1NjIifQ.qVn0_Xp_rzXh5MusCWOgDkx_Rfx0sn3gg-chVeemEMo',
         },
       }),
     }),
@@ -28,7 +28,7 @@ export const userApi = createApi({
           'Content-Type': 'application/json',
           Authorization:
             // TODO: Change this to a real token
-            'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzIwMDU0OTk0LCJqdGkiOiJlNmVhNjc4NWJlZjg0NTMxODI0NThjZmQ3MjczYTZiYyIsInVzZXJfaWQiOiIwNmIyYmY5My0xZmVlLTQ1ODctODdmOC1kMjk4Y2U1Yjc1MzEifQ.ZoF-g6D8Vcv3Ioc1udK4JjeR6_krWOy1uq2BSQnlxSs',
+            'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzIwMDU3MzQ1LCJqdGkiOiI0NzQyOGI5NTNhMTU0MzRiODU4YjE3YjcxNDYwMWUyZiIsInVzZXJfaWQiOiI2MDRkMDNkNy0xYmVjLTQ5NjUtODA2OS03ZjRkZTMxYjM1NjIifQ.qVn0_Xp_rzXh5MusCWOgDkx_Rfx0sn3gg-chVeemEMo',
         },
       }),
     }),

--- a/redux/store/store.ts
+++ b/redux/store/store.ts
@@ -6,6 +6,7 @@ import userReducer from '../features/userSlice';
 import { ordersApi } from '../../pages/api/ordersApi';
 import { productApi } from '../../pages/api/productsApi';
 import { authApi } from '../../pages/api/authApi';
+import { userApi } from '../../pages/api/usersApi';
 
 export const store = configureStore({
   reducer: {
@@ -14,11 +15,13 @@ export const store = configureStore({
     [ordersApi.reducerPath]: ordersApi.reducer,
     [productApi.reducerPath]: productApi.reducer,
     [authApi.reducerPath]: authApi.reducer,
+    [userApi.reducerPath]: userApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat([
       ordersApi.middleware,
       productApi.middleware,
       authApi.middleware,
+      userApi.middleware,
     ]),
 });


### PR DESCRIPTION
## 🖼️ Contexto

Administrador debe poder ver los usuarios y cambiarlos de estado (no admin/admin)

## 🛠️ Cambios realizados

Vista de lista de usuarios busca usuarios reales desde backend y permite cambiar si son staff o no

<img width="1435" alt="Captura de pantalla 2024-06-18 a la(s) 22 14 16" src="https://github.com/Ecommerce-Lupo/efront/assets/69522408/6f20a033-d7b1-4b29-b02b-26f3013d4601">



## 🧐 ¿Cómo se ve o cómo se prueba?

Reemplazar las líneas 17 y 31 de `pages/api/usersApi.ts` por un token de usuario administrador
<img width="1105" alt="Captura de pantalla 2024-06-18 a la(s) 22 20 58" src="https://github.com/Ecommerce-Lupo/efront/assets/69522408/e485f5af-474b-4e54-ae0d-c119d1069b9b">

Hecho eso, dirigirse en el navegador al menú de administrador, opción de Usuarios y probar cambiando el estado de los usuarios

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️  NO desactivar opción de Staff del mismo usuario con el que se activó sesión. Es un caso borde que queda pendiente revisar.
